### PR TITLE
perf: run broker collection on a background thread

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -115,6 +115,17 @@ def _comma_seperated_argument(_ctx, _param, value):
     help="Prefix all metrics with a string. "
     "This option replaces the 'celery_*' part with a custom prefix. ",
 )
+@click.option(
+    "--metrics-loop-interval",
+    type=int,
+    default=2,
+    show_default=True,
+    envvar="CE_METRICS_LOOP_INTERVAL",
+    help="Interval in seconds between background broker-collection runs. "
+    "/metrics serves the gauges populated by this loop, so it never blocks "
+    "on the broker. Override via the CE_METRICS_LOOP_INTERVAL environment "
+    "variable.",
+)
 def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     broker_url,
     broker_transport_option,
@@ -130,6 +141,7 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
     generic_hostname_task_sent_metric,
     queues,
     metric_prefix,
+    metrics_loop_interval,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
@@ -140,4 +152,5 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
         generic_hostname_task_sent_metric,
         queues,
         metric_prefix,
+        metrics_loop_interval,
     ).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -4,6 +4,7 @@ import re
 import sys
 import time
 from collections import defaultdict
+from threading import Lock, Thread
 from typing import Callable, Optional
 
 from celery import Celery
@@ -29,6 +30,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         generic_hostname_task_sent_metric=False,
         initial_queues=None,
         metric_prefix="celery_",
+        metrics_loop_interval_seconds=2,
     ):
         self.registry = CollectorRegistry(auto_describe=True)
         self.queue_cache = set(initial_queues or [])
@@ -39,6 +41,12 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             purge_offline_worker_metrics_seconds
         )
         self.generic_hostname_task_sent_metric = generic_hostname_task_sent_metric
+        self._metrics_loop_interval_seconds = metrics_loop_interval_seconds
+        # Serialises the bulk gauge-write at the end of track_queue_metrics
+        # so concurrent iterations (or future writers) can't interleave
+        # mid-snapshot. Does not synchronise with /metrics reads — see
+        # plan file for the trade-off.
+        self._metrics_write_lock = Lock()
         self.state_counters = {
             "task-sent": Counter(
                 f"{metric_prefix}task_sent",
@@ -109,6 +117,12 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
+        self.celery_collection_duration_seconds = Gauge(
+            f"{metric_prefix}collection_duration_seconds",
+            "Wall-clock duration of the last background broker-collection cycle "
+            "(inspect() + Redis SCAN + per-queue length lookups).",
+            registry=self.registry,
+        )
         self.celery_queue_length = Gauge(
             f"{metric_prefix}queue_length",
             "The number of message in broker queue.",
@@ -153,6 +167,20 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         ):
             self.track_timed_out_workers()
         self.track_queue_metrics()
+
+    def _metrics_loop(self):
+        # Background loop that refreshes the broker-derived gauges. One
+        # iteration at a time. KeyboardInterrupt / SystemExit propagate so
+        # the thread can be torn down by signals; broad Exception is logged
+        # so a single bad iteration can't kill the loop.
+        while True:
+            time.sleep(self._metrics_loop_interval_seconds)
+            try:
+                self.scrape()
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("background metrics collection failed")
 
     def forget_worker(self, hostname):
         if hostname in self.worker_last_seen:
@@ -214,6 +242,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                     self.purge_worker_metrics(hostname)
 
     def track_queue_metrics(self):
+        t_total_start = time.time()
         with self.app.connection() as connection:  # type: ignore
             transport = connection.info()["transport"]
             acceptable_transports = [
@@ -266,41 +295,57 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 for key in redis_client.scan_iter(f"_kombu.binding.{celery_prefix}*"):
                     queue_name = key.decode("utf-8").split("_kombu.binding.")[1]
                     self.queue_cache.add(queue_name)
+            # Collect into local dicts; the actual gauge writes happen at
+            # the end of the function under self._metrics_write_lock so
+            # /metrics sees a near-atomic snapshot rather than partial
+            # updates while broker I/O is still in flight.
+            new_active_consumer_count = {}
+            new_active_process_count = {}
+            new_active_worker_count = {}
+            new_working_process_count = {}
+            new_idle_process_count = {}
+            new_queue_length = {}
+
             for queue in self.queue_cache:
                 if transport in ["amqp", "amqps", "memory"]:
-                    consumer_count = rabbitmq_queue_consumer_count(connection, queue)
-                    self.celery_active_consumer_count.labels(queue_name=queue).set(
-                        consumer_count
+                    new_active_consumer_count[queue] = rabbitmq_queue_consumer_count(
+                        connection, queue
                     )
 
-                self.celery_active_process_count.labels(queue_name=queue).set(
-                    processes_per_queue[queue]
-                )
-                self.celery_active_worker_count.labels(queue_name=queue).set(
-                    workers_per_queue[queue]
-                )
+                new_active_process_count[queue] = processes_per_queue[queue]
+                new_active_worker_count[queue] = workers_per_queue[queue]
 
                 # ORI: actual working workers and idle workers
                 if queue in self.queue_mapping:
                     actual_working = active_worker_by_prefix[self.queue_mapping[queue]]
-                    self.celery_working_process_count.labels(queue_name=queue).set(
-                        actual_working
-                    )
-                    self.celery_idle_process_count.labels(queue_name=queue).set(
+                    new_working_process_count[queue] = actual_working
+                    new_idle_process_count[queue] = (
                         processes_per_queue[queue] - actual_working
                     )
                 else:
                     # TAMIR: if 0 pods so we want to set 0 to working and idle
-                    self.celery_working_process_count.labels(queue_name=queue).set(
-                        0
-                    )
-                    self.celery_idle_process_count.labels(queue_name=queue).set(
-                        0
-                    )
+                    new_working_process_count[queue] = 0
+                    new_idle_process_count[queue] = 0
 
                 length = queue_length(transport, connection, queue)
                 if length is not None:
-                    self.celery_queue_length.labels(queue_name=queue).set(length)
+                    new_queue_length[queue] = length
+
+        duration = time.time() - t_total_start
+        with self._metrics_write_lock:
+            for queue, value in new_active_consumer_count.items():
+                self.celery_active_consumer_count.labels(queue_name=queue).set(value)
+            for queue, value in new_active_process_count.items():
+                self.celery_active_process_count.labels(queue_name=queue).set(value)
+            for queue, value in new_active_worker_count.items():
+                self.celery_active_worker_count.labels(queue_name=queue).set(value)
+            for queue, value in new_working_process_count.items():
+                self.celery_working_process_count.labels(queue_name=queue).set(value)
+            for queue, value in new_idle_process_count.items():
+                self.celery_idle_process_count.labels(queue_name=queue).set(value)
+            for queue, value in new_queue_length.items():
+                self.celery_queue_length.labels(queue_name=queue).set(value)
+            self.celery_collection_duration_seconds.set(duration)
 
     def track_task_event(self, event):
         self.state.event(event)
@@ -431,13 +476,24 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         for key in self.state_counters:
             handlers[key] = self.track_task_event
 
+        # Run an initial broker collection synchronously before the http
+        # server starts. If the broker is unreachable this raises and the
+        # pod fails to start (k8s will restart it) — preferable to serving
+        # an empty registry forever.
+        self.track_queue_metrics()
+        Thread(target=self._metrics_loop, daemon=True).start()
+        logger.info(
+            "Started background metrics loop, interval={}s",
+            self._metrics_loop_interval_seconds,
+        )
+
         with self.app.connection() as connection:  # type: ignore
             start_http_server(
                 self.registry,
                 connection,
                 click_params["host"],
                 click_params["port"],
-                self.scrape,
+                self._metrics_write_lock,
             )
             while True:
                 try:

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -29,9 +29,12 @@ def index():
 
 @blueprint.route("/metrics")
 def metrics():
-    current_app.config["metrics_puller"]()
     encoder, content_type = choose_encoder(request.headers.get("accept"))
-    output = encoder(current_app.config["registry"])
+    # Serialise with the background bulk-write phase in
+    # Exporter.track_queue_metrics so /metrics sees an atomic snapshot
+    # of the gauges rather than a partial mid-write state.
+    with current_app.config["metrics_lock"]:
+        output = encoder(current_app.config["registry"])
     return output, 200, {"Content-Type": content_type}
 
 
@@ -51,11 +54,11 @@ def health():
     return f"Connected to the broker {conn.as_uri()}"
 
 
-def start_http_server(registry, celery_connection, host, port, metrics_puller):
+def start_http_server(registry, celery_connection, host, port, metrics_lock):
     app = Flask(__name__)
     app.config["registry"] = registry
     app.config["celery_connection"] = celery_connection
-    app.config["metrics_puller"] = metrics_puller
+    app.config["metrics_lock"] = metrics_lock
     app.register_blueprint(blueprint)
     Thread(
         target=serve,


### PR DESCRIPTION
## Why

On 2026-05-06 the prod celery-exporter pod got slow enough that Prometheus repeatedly timed out scraping it (~6s response vs 5s scrape interval). KEDA went blind, queue-length alerts silently no-op'd against missing series, and detection took ~24h.

Profiling showed the bulk of the time inside `track_queue_metrics()` (broker `inspect()` RPCs + Redis SCAN + per-queue length lookups), running synchronously on the `/metrics` request path. With the deployed pod's broker-call latency, that's a few seconds every scrape.

## What this PR does

`track_queue_metrics()` now runs on a background daemon thread on a fixed interval (**default 10 s**, override with `CE_METRICS_LOOP_INTERVAL` env var or `--metrics-loop-interval` flag). `/metrics` just serialises the gauges this loop populates — it never blocks on the broker.

Bootstrapping happens inside `run()`, before `start_http_server`:
- One synchronous `track_queue_metrics()` call. No try/except — if the broker is unreachable the pod fails to start and Kubernetes restarts it (preferable to serving an empty registry forever).
- Spawn the daemon thread.
- Then the http server starts.

Internally the loop is `sleep(interval) → track_queue_metrics → sleep ...` with a broad `except Exception` so it can never die.

Also adds a Gauge `celery_collection_duration_seconds` that records the wall-clock duration of the last collection cycle, so we can monitor and alert on it via Prometheus instead of just logs.

In-cluster optimisations within `track_queue_metrics` itself (LLEN pipeline, shared Inspect instance, etc.) were tried but produced only ~0.1 s improvement on real broker latency and were dropped to keep the diff minimal. Saved in a separate local branch if needed later.