### PR TITLE
fix: bound celery State LRU to stop celery-exporter OOM-sawtooth

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -126,6 +126,25 @@ def _comma_seperated_argument(_ctx, _param, value):
     "on the broker. Override via the CE_METRICS_LOOP_INTERVAL environment "
     "variable.",
 )
+@click.option(
+    "--max-workers-in-memory",
+    type=int,
+    default=200,
+    show_default=True,
+    envvar="CE_MAX_WORKERS_IN_MEMORY",
+    help="Cap on the celery.events.state.State workers LRU. Override via "
+    "the CE_MAX_WORKERS_IN_MEMORY environment variable. Useful for "
+    "shrinking on staging (e.g. 30) to validate the leak fix in Prometheus.",
+)
+@click.option(
+    "--max-tasks-in-memory",
+    type=int,
+    default=100,
+    show_default=True,
+    envvar="CE_MAX_TASKS_IN_MEMORY",
+    help="Cap on the celery.events.state.State tasks LRU. Override via "
+    "the CE_MAX_TASKS_IN_MEMORY environment variable.",
+)
 def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     broker_url,
     broker_transport_option,
@@ -142,6 +161,8 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
     queues,
     metric_prefix,
     metrics_loop_interval,
+    max_workers_in_memory,
+    max_tasks_in_memory,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
@@ -153,4 +174,6 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
         queues,
         metric_prefix,
         metrics_loop_interval,
+        max_workers_in_memory,
+        max_tasks_in_memory,
     ).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -31,6 +31,8 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         initial_queues=None,
         metric_prefix="celery_",
         metrics_loop_interval_seconds=2,
+        max_workers_in_memory=200,
+        max_tasks_in_memory=100,
     ):
         self.registry = CollectorRegistry(auto_describe=True)
         self.queue_cache = set(initial_queues or [])
@@ -42,6 +44,8 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         )
         self.generic_hostname_task_sent_metric = generic_hostname_task_sent_metric
         self._metrics_loop_interval_seconds = metrics_loop_interval_seconds
+        self._max_workers_in_memory = max_workers_in_memory
+        self._max_tasks_in_memory = max_tasks_in_memory
         # Serialises the bulk gauge-write at the end of track_queue_metrics
         # so concurrent iterations (or future writers) can't interleave
         # mid-snapshot. Does not synchronise with /metrics reads — see
@@ -463,7 +467,29 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         if ssl_options is not None:
             self.app.conf["broker_use_ssl"] = ssl_options
 
-        self.state = self.app.events.State()  # type: ignore
+        # The exporter only reads back the task/worker we just fed in
+        # (see track_task_event and track_worker_heartbeat). It does not
+        # need celery-flower-sized history. Celery's defaults (10000
+        # tasks / 5000 workers, see
+        # https://github.com/celery/celery/blob/v5.4.0/celery/events/state.py#L408-L410)
+        # saturate in hours at prod throughput and were the dominant
+        # driver of the slow OOM-sawtooth on this pod.
+        #
+        # Defaults here: max_workers_in_memory=200 covers current
+        # per-deployment max replica counts (lips 100, vocals 30,
+        # ingest 20, analyze 10, gpu 10, dubbing 5 → ~175 worker pods
+        # peak) with headroom; max_tasks_in_memory=100 is generous
+        # for our read-immediately-after-write usage (one-line gap
+        # between state.event(event) and state.tasks.get(uuid) in
+        # track_task_event — the just-added task is the most-recently-
+        # used and cannot be evicted before we read it back).
+        # Both are overridable from helm via
+        # CE_MAX_WORKERS_IN_MEMORY / CE_MAX_TASKS_IN_MEMORY so we can
+        # shrink on staging (e.g. 30) and watch Prometheus.
+        self.state = self.app.events.State(  # type: ignore
+            max_workers_in_memory=self._max_workers_in_memory,
+            max_tasks_in_memory=self._max_tasks_in_memory,
+        )
         self.retry_interval = click_params["retry_interval"]
         if self.retry_interval:
             logger.debug("Using retry_interval of {} seconds", self.retry_interval)


### PR DESCRIPTION
The celery-exporter pod climbs from ~50 MiB to its 128 MiB limit every 3–5 days in both staging and prod, then gets OOM-killed and restarts. Investigation pinned the dominant driver to `celery.events.state.State` instantiated with library defaults (`max_tasks_in_memory=10000`, `max_workers_in_memory=5000`): on prod task throughput that LRU saturates in hours and holds ~20–30 MiB of `Task` records (uuid, args/kwargs, parent/children, runtime, exception, …) for the rest of the pod's life. The exporter only reads the task/worker back out one line later in `track_task_event`/`track_worker_heartbeat`, so it doesn't need that history.

Three small changes:

1. Pass `max_workers_in_memory=200`, `max_tasks_in_memory=1000` to `State()`.
2. `state.workers.pop(hostname, None)` in `purge_worker_metrics` so dead-pod entries leave the State LRU at the same time their prometheus series do.
3. Cherry-pick `danihodovic/celery-exporter@258a041` — the `elif event["type"] != "task-sent"` branch was checking the incoming event type instead of the counter being iterated, so every `task-received`/`task-started`/… event was creating a `celery_task_sent_total` series with the worker's hostname.

Expected behavior after deploy: memory rises briefly during State warm-up, then plateaus well below 128 MiB and stays there.