### PR TITLE
fix: share Inspect instance and clear mailbox.unclaimed each cycle

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -259,9 +259,19 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 )
                 return
 
+            # Reuse one Inspect instance per cycle instead of two (commit
+            # 7e3f475's message claimed this but never actually wired it).
+            # Also drop the Mailbox's accumulated unclaimed-replies dict
+            # (kombu/pidbox.py:191,381) — late replies for past broadcasts
+            # have no consumer and otherwise pile up forever in
+            # self.app.control.mailbox.unclaimed, the dominant ongoing
+            # leak driving the celery-exporter OOM-sawtooth.
+            inspect = self.app.control.inspect()
+            self.app.control.mailbox.unclaimed.clear()
+
             concurrency_per_worker = {
                 worker: len(stats["pool"].get("processes", []))
-                for worker, stats in (self.app.control.inspect().stats() or {}).items()
+                for worker, stats in (inspect.stats() or {}).items()
             }
             processes_per_queue = defaultdict(int)
             workers_per_queue = defaultdict(int)
@@ -275,7 +285,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             # request workers to response active queues
             # we need to cache queue info in exporter in case all workers are offline
             # so that no worker response to exporter will make active_queues return None
-            queues = self.app.control.inspect().active_queues() or {}
+            queues = inspect.active_queues() or {}
             for worker, info_list in queues.items():
                 for queue_info in info_list:
                     name = queue_info["name"]


### PR DESCRIPTION
The celery-exporter pod's slow OOM-sawtooth (~11 MiB/day → hits 128 MiB → OOM-kill every 3–5 days) is **not** the State LRU. We verified that on a local v4.6 build by capping `max_workers_in_memory` / `max_tasks_in_memory` to `30` / `30` — baseline RSS dropped from ~50 → 46 MiB (the State LRU does hold ~4 MiB of resident Task/Worker objects) but the slope was unchanged. PR #4 (the State LRU work) is being abandoned in favor of this fix.

The actual driver is **`self.app.control.mailbox.unclaimed`** (a `defaultdict(deque)` at `kombu/pidbox.py:191`). The mailbox is constructed once at `celery/app/control.py:431` and reused for every `inspect()` broadcast in `track_queue_metrics`. In `Mailbox._collect` at `kombu/pidbox.py:381`, any reply whose ticket no longer matches an in-flight broadcast (orphan reply from a dead pod, late RPC reply past the 1s timeout, etc.) gets stashed in `unclaimed[ticket].append(body)` with no cleanup path. At ~43k inspect() broadcasts/day (2s loop interval × 2 calls per cycle) and a small steady orphan-reply rate, this accumulates unboundedly. Also consistent with the observation that the leak rate is identical in staging (~9 workers) and prod (~27 workers) — it scales with inspect() frequency, not worker count.

Two small changes in `track_queue_metrics`:

1. Share **one** Inspect instance for both `stats()` and `active_queues()` calls. (Commit `7e3f475`'s message claimed this but never actually wired it.)
2. `self.app.control.mailbox.unclaimed.clear()` at the top of each cycle. Thread-safe: the metrics-loop thread is the only caller of `inspect()`; the event-consumer thread doesn't touch `control.mailbox`. Each broadcast uses a fresh UUID ticket, so clearing pre-cycle never drops a reply for an in-flight broadcast.

KEDA-safe: `celery_queue_length` (Redis `LLEN`) and `celery_working_process_count` (derived from `worker_tasks_active` gauge populated by heartbeat events) keep producing the same values. Only the housekeeping changes.

Will manually tag `v4.7` from this branch when ready to test on staging.