### PR TITLE
diag: tracemalloc + /debug/mailbox endpoints (DIAGNOSTIC ONLY, do not merge)

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -267,10 +267,10 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             processes_per_queue = defaultdict(int)
             workers_per_queue = defaultdict(int)
 
-            # ORI: collect working workers samples by prefix 
+            # ORI: collect working workers samples by prefix
             active_worker_by_prefix = defaultdict(float)
             for s in self.worker_tasks_active._samples():
-                if m := re.match("^(.*)-\\w+-\\w+$", str(s.labels.get('hostname'))):
+                if m := re.match("^(.*)-\\w+-\\w+$", str(s.labels.get("hostname"))):
                     active_worker_by_prefix[m.group(1)] += s.value
 
             # request workers to response active queues
@@ -284,14 +284,13 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                     workers_per_queue[name] += 1
                     processes_per_queue[name] += concurrency_per_worker.get(worker, 0)
 
-                    # ORI: map queues to worker prefix 
+                    # ORI: map queues to worker prefix
                     if name not in self.queue_mapping:
                         if m := re.match("^\\w+@(.*)-\\w+-\\w+$", worker):
                             self.queue_mapping[name] = m.group(1)
             # TAMIR : allow to get all queues from redis and not only those of active workers
-            celery_prefix = list(self.queue_cache)[0].split(".")[0]
-            # if we in redis get all keys start with celery_prefix
-            if transport in ["redis", "rediss", "sentinel"]:
+            if transport in ["redis", "rediss", "sentinel"] and self.queue_cache:
+                celery_prefix = next(iter(self.queue_cache)).split(".")[0]
                 redis_client = connection.default_channel.client
                 for key in redis_client.scan_iter(f"_kombu.binding.{celery_prefix}*"):
                     queue_name = key.decode("utf-8").split("_kombu.binding.")[1]

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -3,6 +3,7 @@ import json
 import re
 import sys
 import time
+import tracemalloc
 from collections import defaultdict
 from threading import Lock, Thread
 from typing import Callable, Optional
@@ -429,6 +430,12 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         logger.debug("Updated gauge='{}' value='{}'", self.celery_worker_up._name, up)
 
     def run(self, click_params):
+        # Diagnostic-only build: tracemalloc traces every Python allocation
+        # so /debug/tracemalloc can return the top callsites by size. 10
+        # frames per traceback give enough context to attribute leaks to
+        # specific call paths without too much overhead. Intended for
+        # short-lived (hours/days) diagnostic deployments, not steady-state.
+        tracemalloc.start(10)
         logger.remove()
         logger.add(sys.stdout, level=click_params["log_level"])
         self.app = Celery(broker=click_params["broker_url"])
@@ -494,6 +501,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 click_params["host"],
                 click_params["port"],
                 self._metrics_write_lock,
+                exporter=self,
             )
             while True:
                 try:

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1,3 +1,5 @@
+import sys
+import tracemalloc
 from threading import Thread
 
 import kombu.exceptions
@@ -54,11 +56,84 @@ def health():
     return f"Connected to the broker {conn.as_uri()}"
 
 
-def start_http_server(registry, celery_connection, host, port, metrics_lock):
+@blueprint.route("/debug/tracemalloc")
+def debug_tracemalloc():
+    # Return the top-N Python allocation sites by total bytes. Hit this
+    # periodically while reproducing the leak; growth in a specific file:line
+    # is the smoking gun. Output is plain text formatted exactly like
+    # `tracemalloc.Snapshot.statistics()`.
+    if not tracemalloc.is_tracing():
+        return ("tracemalloc not started", 503, {"Content-Type": "text/plain"})
+    n = int(request.args.get("n", "30"))
+    snapshot = tracemalloc.take_snapshot()
+    top_by_lineno = snapshot.statistics("lineno")[:n]
+    by_file = snapshot.statistics("filename")
+    total_bytes = sum(stat.size for stat in by_file)
+    current, peak = tracemalloc.get_traced_memory()
+    lines = [
+        f"tracemalloc current: {current / 1024 / 1024:.2f} MiB",
+        f"tracemalloc peak:    {peak / 1024 / 1024:.2f} MiB",
+        f"sum of all stats:    {total_bytes / 1024 / 1024:.2f} MiB",
+        "",
+        f"Top {n} allocation sites by total bytes (group_by=lineno):",
+    ]
+    for i, stat in enumerate(top_by_lineno, 1):
+        lines.append(f"#{i}: {stat}")
+        # Include the first frame of the traceback for context.
+        if stat.traceback:
+            for frame in list(stat.traceback)[:3]:
+                lines.append(f"    {frame.filename}:{frame.lineno}")
+    lines.append("")
+    lines.append("Top 15 files by total bytes:")
+    for stat in by_file[:15]:
+        lines.append(f"  {stat.size / 1024:.1f} KiB  count={stat.count}  {stat.traceback[0].filename}")
+    return "\n".join(lines), 200, {"Content-Type": "text/plain"}
+
+
+@blueprint.route("/debug/mailbox")
+def debug_mailbox():
+    # Inspect self.app.control.mailbox.unclaimed — the kombu pidbox
+    # accumulator at kombu/pidbox.py:191. Stash for orphan reply tickets;
+    # has no cleanup path. If this dict grows monotonically across calls
+    # to this endpoint, it's a contributor to the exporter's RSS leak.
+    exporter = current_app.config.get("exporter")
+    if exporter is None or not hasattr(exporter, "app"):
+        return ("exporter not available", 503, {"Content-Type": "text/plain"})
+    try:
+        mailbox = exporter.app.control.mailbox
+    except Exception as e:  # pylint: disable=broad-except
+        return (f"mailbox not available: {e!r}", 503, {"Content-Type": "text/plain"})
+    unclaimed = getattr(mailbox, "unclaimed", None)
+    if unclaimed is None:
+        return ("mailbox has no unclaimed attribute", 503, {"Content-Type": "text/plain"})
+    # Snapshot a shallow copy of the keys so we don't iterate a dict that
+    # the metrics-loop thread might be mutating. dict.copy() is atomic.
+    items = list(unclaimed.items())
+    total_entries = sum(len(deque) for _, deque in items)
+    approx_bytes = sys.getsizeof(unclaimed)
+    for k, v in items:
+        approx_bytes += sys.getsizeof(k) + sys.getsizeof(v)
+        for item in v:
+            approx_bytes += sys.getsizeof(item)
+    top = sorted(((str(k), len(v)) for k, v in items), key=lambda x: -x[1])[:20]
+    lines = [
+        f"unclaimed tickets: {len(items)}",
+        f"total entries across all deques: {total_entries}",
+        f"approx total bytes (shallow getsizeof): {approx_bytes}",
+        "",
+        "Top 20 tickets by entry count:",
+    ]
+    for ticket, count in top:
+        lines.append(f"  {ticket}: {count}")
+    return "\n".join(lines), 200, {"Content-Type": "text/plain"}
+
+
+def start_http_server(registry, celery_connection, host, port, metrics_lock, exporter=None):
     app = Flask(__name__)
     app.config["registry"] = registry
     app.config["celery_connection"] = celery_connection
     app.config["metrics_lock"] = metrics_lock
+    app.config["exporter"] = exporter
     app.register_blueprint(blueprint)
     Thread(
         target=serve,

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -128,6 +128,23 @@ def debug_mailbox():
     return "\n".join(lines), 200, {"Content-Type": "text/plain"}
 
 
+def _serve_with_error_logging(app, host, port):
+    # The waitress thread was previously daemon=True with `_quiet=True`
+    # and no exception handling, so any startup failure (port bind error,
+    # import error, missing kombu deps in the slim image) was silently
+    # swallowed — the main thread logged "Started celery-exporter..."
+    # while the bind never happened. This wrapper surfaces the actual
+    # exception so we can see why startup fails in the container.
+    try:
+        logger.info("waitress: about to bind host={} port={}", host, port)
+        serve(app, host=host, port=port, _quiet=False)
+    except SystemExit:
+        raise
+    except BaseException:  # pylint: disable=broad-except
+        logger.exception("waitress crashed during serve()")
+        raise
+
+
 def start_http_server(registry, celery_connection, host, port, metrics_lock, exporter=None):
     app = Flask(__name__)
     app.config["registry"] = registry
@@ -136,9 +153,8 @@ def start_http_server(registry, celery_connection, host, port, metrics_lock, exp
     app.config["exporter"] = exporter
     app.register_blueprint(blueprint)
     Thread(
-        target=serve,
-        args=(app,),
-        kwargs=dict(host=host, port=port, _quiet=True),
+        target=_serve_with_error_logging,
+        args=(app, host, port),
         daemon=True,
     ).start()
     logger.info("Started celery-exporter at host='{}' on port='{}'", host, port)


### PR DESCRIPTION
**Diagnostic-only branch. Do NOT merge.** Builds an image to deploy to staging for ~1 day so we can measure where the ~11 MiB/day RSS growth is actually coming from instead of guessing. After the data is in, this branch is replaced by a targeted fix (PR #5 is the current speculative candidate; this PR will tell us whether PR #5's hypothesis is correct).

## What this adds

1. **`tracemalloc.start(10)` at the top of `Exporter.run()`** — traces every Python allocation from process start with 10 frames per traceback. ~10–20% memory overhead, fine for a short diagnostic deploy.

2. **`GET /debug/tracemalloc[?n=30]`** — plain text, top-N allocation sites by total bytes. Hit periodically across the observation window; the file:line that grows monotonically is the actual leak source.

3. **`GET /debug/mailbox`** — plain text, counts + approximate bytes for `self.app.control.mailbox.unclaimed` (the kombu pidbox accumulator at `kombu/pidbox.py:191`). Targeted test of PR #5's hypothesis:
   - If this grows monotonically across calls → `unclaimed`-dict is a real contributor → PR #5 is the right fix.
   - If this stays ~empty while RSS climbs → PR #5 is the wrong fix; the `/debug/tracemalloc` output tells us where to look.

## Deploy plan

1. Manually build + tag this branch as e.g. `v4.7-diag` (or whatever — *not* `v4.7`, which is reserved for the real fix).
2. Bump `image.tag` in `tethys-devops/.../values.stage` to `v4.7-diag`.
3. Watch staging for ~24h.
4. Periodically `kubectl port-forward` and `curl localhost:9808/debug/mailbox` + `/debug/tracemalloc?n=30`. Save outputs at hour 0, 6, 12, 24 to compare.
5. Once data is collected, revert `image.tag` back to `v4.6` (or whatever was running), close this PR without merging.

Both endpoints are read-only; no production logic is changed.